### PR TITLE
Remove EIP-712 domain type

### DIFF
--- a/packages/ensjs/src/contracts/index.ts
+++ b/packages/ensjs/src/contracts/index.ts
@@ -100,6 +100,5 @@ export {
   offchainRegisterSnippet,
   offchainCommitableSnippet,
   offchainTransferrableSnippet,
-  type DomainData,
   type MessageData,
 } from './offchainResolver.js'

--- a/packages/ensjs/src/contracts/offchainResolver.ts
+++ b/packages/ensjs/src/contracts/offchainResolver.ts
@@ -170,20 +170,6 @@ export const offchainTransferrableSnippet = [
 ] as const
 
 /**
- * @notice Struct used to define the domain of the typed data signature, defined in EIP-712.
- * @param name The user friendly name of the contract that the signature corresponds to.
- * @param version The version of domain object being used.
- * @param chainId The ID of the chain that the signature corresponds to (ie Ethereum mainnet: 1, Goerli testnet: 5, ...).
- * @param verifyingContract The address of the contract that the signature pertains to.
- */
-export type DomainData = {
-  name: string
-  version: string
-  chainId: number
-  verifyingContract: `0x${string}`
-}
-
-/**
  * @notice Struct used to define the message context used to construct a typed data signature, defined in EIP-712,
  * to authorize and define the deferred mutation being performed.
  * @param callData The encoded function to be called


### PR DESCRIPTION
The EIP-712 requires the type `chainId` to be a number instead of a bigint in order to recover the right signer.